### PR TITLE
Use LTS NodeJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update \
     && apt-get install --no-install-recommends -qy git curl bash
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 RUN apt-get install -y nodejs
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Using LTS as per this page

https://github.com/nodesource/distributions#debinstall

Notice of deprecation

```
 Step 12/16 : RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
   ---> Running in fc91f9c27222
  
  ================================================================================
  ================================================================================
  
                                DEPRECATION WARNING                            
  
    Node.js 12.x is no longer actively supported!
  
    You will not receive security or critical stability updates for this version.
  
    You should migrate to a supported version of Node.js as soon as possible.
    Use the installation script that corresponds to the version of Node.js you
    wish to install. e.g.
  
     * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
     * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
     * https://deb.nodesource.com/setup_18.x — Node.js 18 "Eighteen" (current)
  
    Please see https://github.com/nodejs/Release for details about which
    version may be appropriate for you.
  
    The NodeSource Node.js distributions repository contains
    information both about supported versions of Node.js and supported Linux
    distributions. To learn more about usage, see the repository:
      https://github.com/nodesource/distributions

```