### PR TITLE
Update to python v3.8.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8.18-slim
 
 LABEL "com.github.actions.name"="Deploy Pelican Site to GitHub Pages"
 LABEL "com.github.actions.description"="Deploy Pelican Site to GitHub Pages"


### PR DESCRIPTION
The latest version of [pelican-photos plugin](https://github.com/pelican-plugins/photos) (v1.5) requires a python version >= 3.8.1.

Projects that are using this plugin can’t be deployed on GH Pages anymore. This PR fixes this issue.
