### PR TITLE
Push output directory to gh-pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deploy Pelican to Github Pages
 
-Automated deployment of Pelican SSG generated static websites to GitHub Pages. 
+Automated deployment of Pelican SSG generated static websites to GitHub Pages.
 
 GitHub Pages can serve webpages from three predefined places
 1. **main/root**: The root folder of the main branch
@@ -8,7 +8,7 @@ GitHub Pages can serve webpages from three predefined places
 2. **gh-pages/root**: The root folder of any branch named "gh-pages"
 
 ## Prerequisites
-1. Your working directory should be in the `main` branch of your repository. 
+1. Your working directory should be in the `main` branch of your repository.
 2. Ensure you have captured your dependencies in `requirements.txt`. If not you can run the below command
 ```bash
 pip freeze > requirements.txt
@@ -16,7 +16,7 @@ pip freeze > requirements.txt
 
 ## Steps to use
 First create a file named at the path `.github/.workflows/pelican.yml`
-The conents of the file should be 
+The conents of the file should be
 ```yaml
 name: Deploy
 
@@ -26,14 +26,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with: 
+    - uses: actions/checkout@v4
+      with:
         submodules: 'true'
-    - uses: rehanhaider/pelican-to-github-pages@v1.0.3
+    - uses: rehanhaider/pelican-to-github-pages@v1.3.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         GH_PAGES_CNAME: ${{secrets.DOMAIN_CNAME}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,13 +19,15 @@ if [ -n "$PELICAN_THEME_FOLDER" ]; then
 fi
 
 echo 'Building site 👷 '
-pelican ${PELICAN_CONTENT_FOLDER:=content} -s ${PELICAN_CONFIG_FILE:=publishconf.py}
+pelican ${PELICAN_CONTENT_FOLDER:=content} -o output -s ${PELICAN_CONFIG_FILE:=publishconf.py}
 
 echo "Setting Git safe directory (CVE-2022-24765)"
 echo "git config --global --add safe.directory ${GITHUB_WORKSPACE}"
 git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
 echo 'Publishing to GitHub Pages 📤 '
+echo 'change into output directory'
+pushd output
 git init
 git remote add deploy "$remote_repo"
 git checkout $remote_branch || git checkout --orphan $remote_branch
@@ -41,5 +43,7 @@ echo -n 'Files to Commit:' && ls -l | wc -l
 git commit -m "[ci skip] Automated deployment to GitHub Pages on $(date +%s%3N)"
 git push deploy $remote_branch --force
 rm -fr .git
+echo 'leave output directory'
+popd
 
 echo 'Successfully 🎉🕺💃 🎉 deployed to interwebs 🕸'


### PR DESCRIPTION
Maybe I'm using this wrongly. But to me it appears like the idea is to push the generated page only to the `gh-pages` branch. This was however changed by PR #4. So now the `gh-pages` contains the complete repository not just the generated website. And as such the pages do not look as expected when github publishes the branch. This change reverts this to, what I think is the expected behavior.